### PR TITLE
Migrate font assets from DigitalOcean to Cloudflare R2

### DIFF
--- a/src/styles/typeface-trenda.css
+++ b/src/styles/typeface-trenda.css
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'Trenda';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.woff') format('woff'),
-    /* Modern Browsers */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.ttf') format('truetype'),
-    /* Safari, Android, iOS */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.svg#Trenda-Regular') format('svg'); /* Legacy iOS */
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Regular.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Regular.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Regular.woff') format('woff'),
+    /* Modern Browsers */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Regular.ttf') format('truetype'),
+    /* Safari, Android, iOS */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Regular.svg#Trenda-Regular') format('svg'); /* Legacy iOS */
   font-style: normal;
   font-weight: normal;
   text-rendering: optimizeLegibility;
@@ -12,11 +12,11 @@
 
 @font-face {
   font-family: 'Trenda';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.woff') format('woff'),
-    /* Modern Browsers */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.ttf') format('truetype'),
-    /* Safari, Android, iOS */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.svg#Trenda-Regular') format('svg'); /* Legacy iOS */
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-RegularIt.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-RegularIt.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-RegularIt.woff') format('woff'),
+    /* Modern Browsers */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-RegularIt.ttf') format('truetype'),
+    /* Safari, Android, iOS */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-RegularIt.svg#Trenda-Regular') format('svg'); /* Legacy iOS */
   font-style: italic;
   font-weight: normal;
   text-rendering: optimizeLegibility;
@@ -24,11 +24,11 @@
 
 @font-face {
   font-family: 'Trenda';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.woff') format('woff'),
-    /* Modern Browsers */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.ttf') format('truetype'),
-    /* Safari, Android, iOS */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.svg#Trenda-Black') format('svg'); /* Legacy iOS */
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Black.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Black.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Black.woff') format('woff'),
+    /* Modern Browsers */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Black.ttf') format('truetype'),
+    /* Safari, Android, iOS */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-Black.svg#Trenda-Black') format('svg'); /* Legacy iOS */
   font-style: normal;
   font-weight: 800;
   text-rendering: optimizeLegibility;
@@ -36,11 +36,11 @@
 
 @font-face {
   font-family: 'Trenda';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.eot'); /* IE9 Compat Modes */
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.woff') format('woff'),
-    /* Modern Browsers */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.ttf') format('truetype'),
-    /* Safari, Android, iOS */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.svg#Trenda-BlackIt') format('svg'); /* Legacy iOS */
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-BlackIt.eot'); /* IE9 Compat Modes */
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-BlackIt.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-BlackIt.woff') format('woff'),
+    /* Modern Browsers */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-BlackIt.ttf') format('truetype'),
+    /* Safari, Android, iOS */ url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/trenda/Trenda-BlackIt.svg#Trenda-BlackIt') format('svg'); /* Legacy iOS */
   font-style: italic;
   font-weight: 800;
   text-rendering: optimizeLegibility;

--- a/src/styles/typeface-trenda.css
+++ b/src/styles/typeface-trenda.css
@@ -1,10 +1,10 @@
 @font-face {
   font-family: 'Trenda';
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Regular.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Regular.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Regular.woff') format('woff'),
-    /* Modern Browsers */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Regular.ttf') format('truetype'),
-    /* Safari, Android, iOS */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Regular.svg#Trenda-Regular') format('svg'); /* Legacy iOS */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.woff') format('woff'),
+    /* Modern Browsers */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.ttf') format('truetype'),
+    /* Safari, Android, iOS */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Regular.svg#Trenda-Regular') format('svg'); /* Legacy iOS */
   font-style: normal;
   font-weight: normal;
   text-rendering: optimizeLegibility;
@@ -12,11 +12,11 @@
 
 @font-face {
   font-family: 'Trenda';
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-RegularIt.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-RegularIt.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-RegularIt.woff') format('woff'),
-    /* Modern Browsers */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-RegularIt.ttf') format('truetype'),
-    /* Safari, Android, iOS */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-RegularIt.svg#Trenda-Regular') format('svg'); /* Legacy iOS */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.woff') format('woff'),
+    /* Modern Browsers */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.ttf') format('truetype'),
+    /* Safari, Android, iOS */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-RegularIt.svg#Trenda-Regular') format('svg'); /* Legacy iOS */
   font-style: italic;
   font-weight: normal;
   text-rendering: optimizeLegibility;
@@ -24,11 +24,11 @@
 
 @font-face {
   font-family: 'Trenda';
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Black.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Black.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Black.woff') format('woff'),
-    /* Modern Browsers */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Black.ttf') format('truetype'),
-    /* Safari, Android, iOS */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-Black.svg#Trenda-Black') format('svg'); /* Legacy iOS */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.woff') format('woff'),
+    /* Modern Browsers */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.ttf') format('truetype'),
+    /* Safari, Android, iOS */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-Black.svg#Trenda-Black') format('svg'); /* Legacy iOS */
   font-style: normal;
   font-weight: 800;
   text-rendering: optimizeLegibility;
@@ -36,11 +36,11 @@
 
 @font-face {
   font-family: 'Trenda';
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-BlackIt.eot'); /* IE9 Compat Modes */
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-BlackIt.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-BlackIt.woff') format('woff'),
-    /* Modern Browsers */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-BlackIt.ttf') format('truetype'),
-    /* Safari, Android, iOS */ url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/trenda/Trenda-BlackIt.svg#Trenda-BlackIt') format('svg'); /* Legacy iOS */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.eot'); /* IE9 Compat Modes */
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.woff') format('woff'),
+    /* Modern Browsers */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.ttf') format('truetype'),
+    /* Safari, Android, iOS */ url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/trenda/Trenda-BlackIt.svg#Trenda-BlackIt') format('svg'); /* Legacy iOS */
   font-style: italic;
   font-weight: 800;
   text-rendering: optimizeLegibility;

--- a/src/styles/typeface-wattermellon.css
+++ b/src/styles/typeface-wattermellon.css
@@ -1,8 +1,8 @@
 @font-face {
   font-family: 'Wattermellon';
-  src: url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/wattermellon/Wattermellon.otf') format('opentype'),
-    url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/wattermellon/Wattermellon.woff') format('woff'),
-    url('https://fsvdr-fonts.sfo2.digitaloceanspaces.com/wattermellon/Wattermellon.ttf') format('truetype');
+  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/wattermellon/Wattermellon.otf') format('opentype'),
+    url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/wattermellon/Wattermellon.woff') format('woff'),
+    url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/wattermellon/Wattermellon.ttf') format('truetype');
   font-style: normal;
   font-weight: normal;
   text-rendering: optimizeLegibility;

--- a/src/styles/typeface-wattermellon.css
+++ b/src/styles/typeface-wattermellon.css
@@ -1,8 +1,8 @@
 @font-face {
   font-family: 'Wattermellon';
-  src: url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/wattermellon/Wattermellon.otf') format('opentype'),
-    url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/wattermellon/Wattermellon.woff') format('woff'),
-    url('https://102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/wattermellon/Wattermellon.ttf') format('truetype');
+  src: url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/wattermellon/Wattermellon.otf') format('opentype'),
+    url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/wattermellon/Wattermellon.woff') format('woff'),
+    url('https://pub-fd7ef24f455244ba96868abce0b6d30a.r2.dev/fonts/wattermellon/Wattermellon.ttf') format('truetype');
   font-style: normal;
   font-weight: normal;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary
This PR migrates all font asset URLs from DigitalOcean Spaces to Cloudflare R2 storage, updating the font-face declarations in the typeface stylesheets.

## Changes
- Updated Trenda font URLs (Regular, RegularIt, Black, BlackIt variants) from `fsvdr-fonts.sfo2.digitaloceanspaces.com` to `102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/`
- Updated Wattermellon font URLs from `fsvdr-fonts.sfo2.digitaloceanspaces.com` to `102e81b89588dae95fe3fe66184c1b24.r2.cloudflarestorage.com/dot-me/fonts/`
- All font file formats (eot, woff, ttf, svg, otf) are now served from the new Cloudflare R2 bucket

## Implementation Details
- No changes to font-face declarations, font weights, styles, or rendering properties
- All font variants and formats are preserved with identical structure
- The migration maintains backward compatibility with all supported browsers (IE6+, modern browsers, Safari, Android, iOS)

https://claude.ai/code/session_011iaa9wef6pPqjwquvcQKyM